### PR TITLE
feat: implement CloudWatch collector with log reduction pipeline

### DIFF
--- a/autopsy/collectors/cloudwatch.py
+++ b/autopsy/collectors/cloudwatch.py
@@ -7,7 +7,33 @@ truncation, and token budgeting.
 
 from __future__ import annotations
 
+import hashlib
+import re
+import time
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+from rich.console import Console
+
 from autopsy.collectors.base import BaseCollector, CollectedData
+from autopsy.utils.errors import AWSAuthError, AWSPermissionError, NoDataError
+
+console = Console(stderr=True)
+
+DEFAULT_QUERY = """\
+fields @timestamp, @message, @logStream
+| filter @message like /(?i)(error|exception|fatal|panic|timeout|5\\d{2})/
+| sort @timestamp desc
+| limit 200
+"""
+
+TOKEN_BUDGET = 6000
+MAX_ENTRY_CHARS = 500
+MAX_STACK_FRAMES = 5
+QUERY_POLL_INTERVAL = 1.0
+QUERY_POLL_MAX_WAIT = 120.0
+CHARS_PER_TOKEN = 4  # conservative estimate in lieu of tiktoken dependency
 
 
 class CloudWatchCollector(BaseCollector):
@@ -31,16 +57,21 @@ class CloudWatchCollector(BaseCollector):
             AWSAuthError: On expired or invalid credentials.
             AWSPermissionError: On missing logs:StartQuery permission.
         """
-        raise NotImplementedError
+        client = _make_client(config)
+        try:
+            client.describe_log_groups(limit=1)
+        except ClientError as exc:
+            _raise_for_client_error(exc)
+        except BotoCoreError as exc:
+            raise AWSAuthError(
+                message=f"AWS credential error: {exc}",
+                hint="Run 'aws configure' or check AWS_PROFILE.",
+                docs_url="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
+            ) from exc
+        return True
 
     def collect(self, config: dict) -> CollectedData:
         """Pull error logs from CloudWatch and apply reduction pipeline.
-
-        Pipeline stages:
-        1. Query-level regex filter (~90% reduction)
-        2. Deduplication by message template (~60% reduction)
-        3. Truncation to 500 chars per entry (~40% reduction)
-        4. Token budget hard cap at 6000 tokens (FIFO eviction)
 
         Args:
             config: The 'aws' section of AutopsyConfig.
@@ -53,4 +84,330 @@ class CloudWatchCollector(BaseCollector):
             AWSPermissionError: On IAM permission issues.
             NoDataError: On zero results.
         """
-        raise NotImplementedError
+        client = _make_client(config)
+        time_window = config.get("time_window", 30)
+        log_groups = config.get("log_groups", [])
+
+        end_time = datetime.now(tz=timezone.utc)
+        start_time = end_time - timedelta(minutes=time_window)
+
+        raw_entries: list[dict] = []
+        for lg in log_groups:
+            raw_entries.extend(
+                _run_insights_query(client, lg, start_time, end_time)
+            )
+
+        total_before = len(raw_entries)
+
+        if total_before == 0:
+            raise NoDataError(
+                message=f"No error logs found in the last {time_window} minutes.",
+                hint=(
+                    "Check that your log groups are correct and contain recent "
+                    "error-level messages. Try increasing --time-window."
+                ),
+            )
+
+        # --- Stage 2: Deduplication ---
+        entries = _deduplicate(raw_entries)
+
+        # --- Stage 3: Truncation ---
+        entries = [_truncate_entry(e) for e in entries]
+
+        # --- Stage 4: Token budget ---
+        entries, was_truncated = _apply_token_budget(entries)
+
+        return CollectedData(
+            source="cloudwatch",
+            data_type="logs",
+            entries=entries,
+            time_range=(start_time, end_time),
+            raw_query=DEFAULT_QUERY.strip(),
+            entry_count=total_before,
+            truncated=was_truncated or len(entries) < total_before,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(config: dict) -> boto3.client:
+    """Build a CloudWatch Logs boto3 client from config.
+
+    Args:
+        config: The 'aws' section dict.
+
+    Returns:
+        boto3 CloudWatch Logs client.
+    """
+    session_kwargs: dict = {}
+    if config.get("profile"):
+        session_kwargs["profile_name"] = config["profile"]
+
+    session = boto3.Session(**session_kwargs)
+    return session.client("logs", region_name=config.get("region", "us-east-1"))
+
+
+def _run_insights_query(
+    client: boto3.client,
+    log_group: str,
+    start: datetime,
+    end: datetime,
+) -> list[dict]:
+    """Execute a CloudWatch Logs Insights query and poll for results.
+
+    Args:
+        client: boto3 logs client.
+        log_group: CloudWatch log group name.
+        start: Query start time (UTC).
+        end: Query end time (UTC).
+
+    Returns:
+        List of raw result dicts with @timestamp, @message, @logStream.
+
+    Raises:
+        AWSAuthError: On credential failure.
+        AWSPermissionError: On missing IAM permissions.
+    """
+    try:
+        response = client.start_query(
+            logGroupName=log_group,
+            startTime=int(start.timestamp()),
+            endTime=int(end.timestamp()),
+            queryString=DEFAULT_QUERY,
+        )
+    except ClientError as exc:
+        _raise_for_client_error(exc)
+
+    query_id = response["queryId"]
+    return _poll_query(client, query_id)
+
+
+def _poll_query(client: boto3.client, query_id: str) -> list[dict]:
+    """Poll a Logs Insights query until complete.
+
+    Args:
+        client: boto3 logs client.
+        query_id: ID from start_query response.
+
+    Returns:
+        Flattened list of result entry dicts.
+    """
+    elapsed = 0.0
+    while elapsed < QUERY_POLL_MAX_WAIT:
+        result = client.get_query_results(queryId=query_id)
+        status = result.get("status", "")
+        if status == "Complete":
+            return _flatten_results(result.get("results", []))
+        if status in ("Failed", "Cancelled", "Timeout"):
+            return []
+        time.sleep(QUERY_POLL_INTERVAL)
+        elapsed += QUERY_POLL_INTERVAL
+    return []
+
+
+def _flatten_results(raw_results: list[list[dict]]) -> list[dict]:
+    """Convert Logs Insights result rows into flat dicts.
+
+    Each row is a list of {field, value} dicts. Flatten to {field: value}.
+
+    Args:
+        raw_results: Raw results from get_query_results.
+
+    Returns:
+        List of flat entry dicts.
+    """
+    entries = []
+    for row in raw_results:
+        entry: dict = {}
+        for field_obj in row:
+            key = field_obj.get("field", "")
+            val = field_obj.get("value", "")
+            if key and not key.startswith("@ptr"):
+                entry[key] = val
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def _raise_for_client_error(exc: ClientError) -> None:
+    """Map a boto3 ClientError to the appropriate Autopsy exception.
+
+    Args:
+        exc: The caught ClientError.
+
+    Raises:
+        AWSAuthError: On auth-related error codes.
+        AWSPermissionError: On access-denied error codes.
+    """
+    code = exc.response.get("Error", {}).get("Code", "")
+
+    if code in (
+        "ExpiredTokenException",
+        "UnrecognizedClientException",
+        "InvalidSignatureException",
+        "AuthFailure",
+    ):
+        raise AWSAuthError(
+            message=f"AWS authentication failed: {code}",
+            hint="Run 'aws configure' or set AWS_PROFILE and try again.",
+            docs_url="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
+        ) from exc
+
+    if code in ("AccessDeniedException", "AccessDenied"):
+        raise AWSPermissionError(
+            message=f"AWS permission denied: {code}",
+            hint=(
+                "Ensure your IAM user/role has logs:StartQuery, "
+                "logs:GetQueryResults, and logs:DescribeLogGroups permissions."
+            ),
+            docs_url="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/permissions-reference-cwl.html",
+        ) from exc
+
+    raise AWSAuthError(
+        message=f"AWS API error ({code}): {exc}",
+        hint="Check your AWS credentials and region configuration.",
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Reduction pipeline
+# ---------------------------------------------------------------------------
+
+
+_TEMPLATE_RE = re.compile(
+    r"(0x[0-9a-fA-F]+|"          # hex addresses
+    r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[^\s]*|"  # timestamps
+    r"\b[0-9a-f]{8,}\b|"         # long hex ids
+    r"\d+)"                       # any numeric sequence
+)
+
+
+def _template_hash(message: str) -> str:
+    """Produce a hash of the message with variable parts normalized.
+
+    Replaces numbers, hex addresses, timestamps, and UUIDs with
+    placeholders so structurally identical messages map to the same hash.
+
+    Args:
+        message: Raw log message string.
+
+    Returns:
+        Hex digest of the normalized template.
+    """
+    normalized = _TEMPLATE_RE.sub("<*>", message)
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def _deduplicate(entries: list[dict]) -> list[dict]:
+    """Stage 2: Deduplicate by message template, keeping 1 instance + count.
+
+    Args:
+        entries: Raw log entries from the query.
+
+    Returns:
+        Deduplicated entries with an 'occurrences' count field.
+    """
+    seen: dict[str, dict] = {}
+    counts: dict[str, int] = {}
+
+    for entry in entries:
+        msg = entry.get("@message", "")
+        tmpl = _template_hash(msg)
+        if tmpl not in seen:
+            seen[tmpl] = entry
+            counts[tmpl] = 1
+        else:
+            counts[tmpl] += 1
+
+    result = []
+    for tmpl, entry in seen.items():
+        entry_copy = dict(entry)
+        entry_copy["occurrences"] = counts[tmpl]
+        result.append(entry_copy)
+    return result
+
+
+def _truncate_stack_trace(message: str) -> str:
+    """Trim stack traces to the top N frames.
+
+    Args:
+        message: Log message potentially containing a stack trace.
+
+    Returns:
+        Truncated message with at most MAX_STACK_FRAMES stack frames.
+    """
+    lines = message.split("\n")
+    frame_indices: list[int] = []
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(("at ", "File ", "Traceback", "  File ")):
+            frame_indices.append(i)
+
+    if len(frame_indices) <= MAX_STACK_FRAMES:
+        return message
+
+    keep_up_to = frame_indices[MAX_STACK_FRAMES - 1]
+    kept = lines[: keep_up_to + 1]
+    omitted = len(frame_indices) - MAX_STACK_FRAMES
+    kept.append(f"  ... ({omitted} more frames omitted)")
+    return "\n".join(kept)
+
+
+def _truncate_entry(entry: dict) -> dict:
+    """Stage 3: Truncate a single entry's message to MAX_ENTRY_CHARS.
+
+    Also trims stack traces to top MAX_STACK_FRAMES frames.
+
+    Args:
+        entry: A log entry dict with '@message' key.
+
+    Returns:
+        Entry with truncated message.
+    """
+    msg = entry.get("@message", "")
+    msg = _truncate_stack_trace(msg)
+    if len(msg) > MAX_ENTRY_CHARS:
+        msg = msg[:MAX_ENTRY_CHARS] + "…"
+    result = dict(entry)
+    result["@message"] = msg
+    return result
+
+
+def _estimate_tokens(entries: list[dict]) -> int:
+    """Estimate token count for a list of entries.
+
+    Uses a simple character-based heuristic (1 token ~ 4 chars).
+
+    Args:
+        entries: Log entries to measure.
+
+    Returns:
+        Estimated token count.
+    """
+    total_chars = sum(len(str(e)) for e in entries)
+    return total_chars // CHARS_PER_TOKEN
+
+
+def _apply_token_budget(entries: list[dict]) -> tuple[list[dict], bool]:
+    """Stage 4: Evict oldest entries (FIFO) until under TOKEN_BUDGET.
+
+    Args:
+        entries: Deduplicated and truncated log entries.
+
+    Returns:
+        (entries within budget, whether any were evicted).
+    """
+    if _estimate_tokens(entries) <= TOKEN_BUDGET:
+        return entries, False
+
+    kept: list[dict] = []
+    for entry in entries:
+        candidate = [*kept, entry]
+        if _estimate_tokens(candidate) > TOKEN_BUDGET:
+            break
+        kept.append(entry)
+
+    return kept, True

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,3 +1,355 @@
 """Tests for autopsy.collectors.cloudwatch — CloudWatch collector."""
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from autopsy.collectors.cloudwatch import (
+    CloudWatchCollector,
+    _apply_token_budget,
+    _deduplicate,
+    _estimate_tokens,
+    _template_hash,
+    _truncate_entry,
+    _truncate_stack_trace,
+)
+from autopsy.utils.errors import AWSAuthError, AWSPermissionError, NoDataError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _aws_config() -> dict:
+    """Minimal AWS config for testing."""
+    return {
+        "region": "us-east-1",
+        "log_groups": ["/aws/lambda/my-api"],
+        "time_window": 30,
+    }
+
+
+def _make_log_row(timestamp: str, message: str, stream: str = "stream-1") -> list[dict]:
+    """Build a Logs Insights result row."""
+    return [
+        {"field": "@timestamp", "value": timestamp},
+        {"field": "@message", "value": message},
+        {"field": "@logStream", "value": stream},
+        {"field": "@ptr", "value": "ptr-ignore-me"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Template hashing
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateHash:
+    """Message template normalization for dedup."""
+
+    def test_identical_messages_same_hash(self) -> None:
+        assert _template_hash("ERROR in handler") == _template_hash("ERROR in handler")
+
+    def test_different_numbers_same_hash(self) -> None:
+        h1 = _template_hash("Timeout after 3000ms on request 42")
+        h2 = _template_hash("Timeout after 5000ms on request 99")
+        assert h1 == h2
+
+    def test_different_timestamps_same_hash(self) -> None:
+        h1 = _template_hash("Error at 2026-03-06T10:00:00Z in handler")
+        h2 = _template_hash("Error at 2026-03-06T12:30:00Z in handler")
+        assert h1 == h2
+
+    def test_different_hex_ids_same_hash(self) -> None:
+        h1 = _template_hash("Request abcdef12 failed")
+        h2 = _template_hash("Request 12345678 failed")
+        assert h1 == h2
+
+    def test_structurally_different_messages(self) -> None:
+        h1 = _template_hash("NullPointerException in handler")
+        h2 = _template_hash("TimeoutException in scheduler")
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Deduplication (Stage 2)
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicate:
+    """Stage 2: hash-based dedup with occurrence counting."""
+
+    def test_unique_messages_kept(self) -> None:
+        entries = [
+            {"@message": "Error A", "@timestamp": "t1"},
+            {"@message": "Error B", "@timestamp": "t2"},
+        ]
+        result = _deduplicate(entries)
+        assert len(result) == 2
+
+    def test_duplicates_collapsed_with_count(self) -> None:
+        entries = [
+            {"@message": "Timeout after 100ms", "@timestamp": "t1"},
+            {"@message": "Timeout after 200ms", "@timestamp": "t2"},
+            {"@message": "Timeout after 300ms", "@timestamp": "t3"},
+        ]
+        result = _deduplicate(entries)
+        assert len(result) == 1
+        assert result[0]["occurrences"] == 3
+
+    def test_mixed_messages(self) -> None:
+        entries = [
+            {"@message": "Timeout after 100ms", "@timestamp": "t1"},
+            {"@message": "NullPointer in handler", "@timestamp": "t2"},
+            {"@message": "Timeout after 200ms", "@timestamp": "t3"},
+        ]
+        result = _deduplicate(entries)
+        assert len(result) == 2
+        timeout_entry = next(e for e in result if "Timeout" in e["@message"])
+        assert timeout_entry["occurrences"] == 2
+
+    def test_empty_input(self) -> None:
+        assert _deduplicate([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Truncation (Stage 3)
+# ---------------------------------------------------------------------------
+
+
+class TestTruncation:
+    """Stage 3: per-entry truncation and stack trace trimming."""
+
+    def test_short_message_unchanged(self) -> None:
+        entry = {"@message": "short error"}
+        result = _truncate_entry(entry)
+        assert result["@message"] == "short error"
+
+    def test_long_message_truncated(self) -> None:
+        entry = {"@message": "x" * 1000}
+        result = _truncate_entry(entry)
+        assert len(result["@message"]) == 501  # 500 + ellipsis char
+
+    def test_stack_trace_trimmed(self) -> None:
+        frames = "\n".join(
+            f"  at com.example.Class{i}.method(Class{i}.java:{i})"
+            for i in range(20)
+        )
+        msg = f"java.lang.NullPointerException\n{frames}"
+        result = _truncate_stack_trace(msg)
+        at_lines = [line for line in result.split("\n") if line.strip().startswith("at ")]
+        assert len(at_lines) == 5
+
+    def test_short_stack_not_trimmed(self) -> None:
+        frames = "\n".join(f"  at Class{i}.method()" for i in range(3))
+        msg = f"Error\n{frames}"
+        result = _truncate_stack_trace(msg)
+        assert "omitted" not in result
+
+    def test_original_entry_not_mutated(self) -> None:
+        entry = {"@message": "x" * 1000, "@timestamp": "t1"}
+        _truncate_entry(entry)
+        assert len(entry["@message"]) == 1000
+
+
+# ---------------------------------------------------------------------------
+# Token budget (Stage 4)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudget:
+    """Stage 4: FIFO eviction to stay within token budget."""
+
+    def test_under_budget_no_eviction(self) -> None:
+        entries = [{"@message": "short"}]
+        result, truncated = _apply_token_budget(entries)
+        assert result == entries
+        assert truncated is False
+
+    def test_over_budget_evicts(self) -> None:
+        big_entry = {"@message": "x" * 30000}
+        entries = [big_entry, big_entry, big_entry]
+        result, truncated = _apply_token_budget(entries)
+        assert len(result) < len(entries)
+        assert truncated is True
+
+    def test_estimate_tokens_basic(self) -> None:
+        entries = [{"@message": "a" * 400}]
+        tokens = _estimate_tokens(entries)
+        assert tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# CloudWatchCollector.validate_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfig:
+    """Auth and permission validation via mocked boto3."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_valid_credentials(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_log_groups.return_value = {"logGroups": []}
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        assert collector.validate_config(_aws_config()) is True
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_expired_token_raises(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        error_response = {"Error": {"Code": "ExpiredTokenException", "Message": "expired"}}
+        mock_client.describe_log_groups.side_effect = ClientError(
+            error_response, "DescribeLogGroups"
+        )
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        with pytest.raises(AWSAuthError):
+            collector.validate_config(_aws_config())
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_access_denied_raises(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        error_response = {"Error": {"Code": "AccessDeniedException", "Message": "denied"}}
+        mock_client.describe_log_groups.side_effect = ClientError(
+            error_response, "DescribeLogGroups"
+        )
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        with pytest.raises(AWSPermissionError):
+            collector.validate_config(_aws_config())
+
+
+# ---------------------------------------------------------------------------
+# CloudWatchCollector.collect
+# ---------------------------------------------------------------------------
+
+
+class TestCollect:
+    """Full collect() with mocked boto3 calls."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_happy_path(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _make_log_row("2026-03-06T10:00:00Z", "ERROR: NullPointerException in handler"),
+                _make_log_row("2026-03-06T10:01:00Z", "ERROR: TimeoutException after 5000ms"),
+            ],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
+
+        assert result.source == "cloudwatch"
+        assert result.data_type == "logs"
+        assert len(result.entries) == 2
+        assert result.entry_count == 2
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_empty_results_raises_no_data(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        with pytest.raises(NoDataError):
+            collector.collect(_aws_config())
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_dedup_applied(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _make_log_row("t1", "Timeout after 100ms"),
+                _make_log_row("t2", "Timeout after 200ms"),
+                _make_log_row("t3", "Timeout after 300ms"),
+                _make_log_row("t4", "NullPointer in handler"),
+            ],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
+
+        assert result.entry_count == 4
+        assert len(result.entries) == 2
+        assert result.truncated is True
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_auth_error_on_start_query(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        error_response = {"Error": {"Code": "ExpiredTokenException", "Message": "expired"}}
+        mock_client.start_query.side_effect = ClientError(error_response, "StartQuery")
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        with pytest.raises(AWSAuthError):
+            collector.collect(_aws_config())
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_profile_passed_to_session(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _make_log_row("t1", "ERROR: something broke"),
+            ],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        config = _aws_config()
+        config["profile"] = "my-profile"
+        collector = CloudWatchCollector()
+        collector.collect(config)
+
+        mock_session_cls.assert_called_with(profile_name="my-profile")
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_multiple_log_groups(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [
+                _make_log_row("t1", "ERROR: from group A"),
+            ],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        config = _aws_config()
+        config["log_groups"] = ["/aws/lambda/api-a", "/aws/lambda/api-b"]
+        collector = CloudWatchCollector()
+        result = collector.collect(config)
+
+        assert mock_client.start_query.call_count == 2
+        assert result.entry_count == 2
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_failed_query_returns_empty(self, mock_session_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_query.return_value = {"queryId": "q-123"}
+        mock_client.get_query_results.return_value = {
+            "status": "Failed",
+            "results": [],
+        }
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        collector = CloudWatchCollector()
+        with pytest.raises(NoDataError):
+            collector.collect(_aws_config())


### PR DESCRIPTION
## Summary
- Implement CloudWatch Logs Insights collector (`autopsy/collectors/cloudwatch.py`)
- 4-stage log reduction pipeline: query-level regex filtering, message templating/deduplication, stack trace truncation, and token budgeting (FIFO eviction)
- Error handling for AWS auth, permission, and no-data scenarios (`AWSAuthError`, `AWSPermissionError`, `NoDataError`)

## Changes
- `autopsy/collectors/cloudwatch.py` — full collector implementation (+373 lines)
- `tests/test_cloudwatch.py` — 27 tests covering collector, reduction pipeline, and error paths (+352 lines)

## Test plan
- [x] All 27 CloudWatch tests pass (`pytest tests/test_cloudwatch.py`)
- [x] All 55 project tests pass (`pytest`)
- [x] Ruff clean — no lint errors