### PR TITLE
feat: CloudWatch Logs Insights collector, tests, and GitHub exception…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,95 @@
 # Autopsy CLI
 
-AI-powered incident diagnosis for engineering teams. Diagnose production incidents in 30 seconds.
+[![CI](https://github.com/zaappy/autopsy/actions/workflows/ci.yml/badge.svg)](https://github.com/zaappy/autopsy/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/autopsy-cli.svg)](https://pypi.org/project/autopsy-cli/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+**AI-powered incident diagnosis for engineering teams.** Pull production error logs and recent deploys, send them to an LLM, and get a structured root cause analysis in the terminal in under a minute. Zero-trust: your data never leaves your environment.
+
+<!-- TODO: Add demo GIF when available -->
+<!-- ![Demo](docs/demo.gif) -->
 
 ## Install
 
 ```bash
-pip install -e .
+pip install autopsy-cli
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/zaappy/autopsy.git && cd autopsy
+pip install -e ".[dev]"
 ```
 
 ## Quick Start
 
 ```bash
-autopsy init
-autopsy diagnose
+autopsy init      # Interactive config wizard (~/.autopsy/config.yaml)
+autopsy diagnose  # Run diagnosis (CloudWatch + GitHub → AI → panels)
 ```
+
+Three steps: **install → init → diagnose.**
+
+## Configuration
+
+After `autopsy init`, edit `~/.autopsy/config.yaml` or re-run the wizard. You need:
+
+| Section   | Purpose |
+|----------|---------|
+| **aws**  | CloudWatch region, log groups, time window (minutes). Uses your AWS CLI credentials. |
+| **github** | Repo (`owner/repo`), branch, number of recent commits to analyze. Uses `GITHUB_TOKEN`. |
+| **ai**   | Provider (`anthropic` or `openai`), model, API key env var. |
+
+Set the env vars referenced in config (e.g. `GITHUB_TOKEN`, `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`) before running `autopsy diagnose`.
+
+```bash
+autopsy config show       # Print config (secrets masked)
+autopsy config validate   # Check env vars and connectivity
+```
+
+## How It Works
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌─────────────┐     ┌──────────────┐
+│   Config    │────▶│  Data Collectors │────▶│  AI Engine  │────▶│  Renderers   │
+│ ~/.autopsy  │     │  CloudWatch      │     │  (Claude /   │     │  Terminal or │
+│ config.yaml │     │  GitHub          │     │   OpenAI)    │     │  JSON        │
+└─────────────┘     └──────────────────┘     └─────────────┘     └──────────────┘
+                           │                          │
+                           ▼                          ▼
+                    Logs + recent commits      Structured diagnosis:
+                    (deduped, truncated)       root cause, deploy, fix, timeline
+```
+
+1. **Collect** — CloudWatch Logs Insights (error-level) and GitHub (last N commits + diffs).
+2. **Reduce** — Log dedup and token budget; diff filters (code files only, cap per file).
+3. **Diagnose** — Single prompt with logs + deploys; LLM returns JSON (root cause, correlated deploy, suggested fix, timeline).
+4. **Render** — Rich panels in the terminal or `--json` for piping.
+
+## CLI Reference
+
+| Command | Description |
+|--------|-------------|
+| `autopsy init` | Interactive config wizard |
+| `autopsy diagnose` | Run full diagnosis pipeline |
+| `autopsy diagnose --json` | Output raw JSON |
+| `autopsy diagnose --time-window 15` | Override log window (minutes) |
+| `autopsy diagnose --log-group /aws/lambda/foo` | Override log groups (repeatable) |
+| `autopsy diagnose --provider openai` | Use OpenAI instead of Anthropic |
+| `autopsy config show` | Print config |
+| `autopsy config validate` | Check credentials |
+| `autopsy version` / `autopsy --version` | CLI version, prompt version, Python version |
+
+## Contributing
+
+1. Fork the repo and create a branch.
+2. Install dev deps: `pip install -e ".[dev]"`.
+3. Run lint and tests: `ruff check . && pytest`.
+4. Open a PR against `main`.
+
+We follow the layout and conventions in the repo (collectors, AI engine, renderers, no business logic in `cli.py`).
 
 ## License
 
-MIT
+MIT. See [LICENSE](LICENSE).

--- a/autopsy/cli.py
+++ b/autopsy/cli.py
@@ -32,7 +32,27 @@ def _handle_error(err: AutopsyError) -> None:
     sys.exit(1)
 
 
+def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
+    if not value:
+        return
+    from autopsy import PROMPT_VERSION, __version__
+
+    out = Console()
+    out.print(f"[bold]autopsy[/bold]  {__version__}")
+    out.print(f"[bold]prompt[/bold]    {PROMPT_VERSION}")
+    out.print(f"[bold]python[/bold]    {sys.version.split()[0]}")
+    ctx.exit()
+
+
 @click.group()
+@click.option(
+    "--version",
+    is_flag=True,
+    callback=_print_version,
+    expose_value=False,
+    is_eager=True,
+    help="Show CLI version, prompt version, and Python version.",
+)
 def cli() -> None:
     """Autopsy — AI-powered incident diagnosis for engineering teams."""
 
@@ -60,7 +80,7 @@ def init() -> None:
 
 @cli.command()
 @click.option("--time-window", type=int, help="Minutes of logs to pull (5-60).")
-@click.option("--log-group", multiple=True, help="Override log groups from config.")
+@click.option("--log-group", "log_groups", multiple=True, help="Override log groups from config.")
 @click.option(
     "--provider",
     type=click.Choice(["anthropic", "openai"]),
@@ -70,14 +90,44 @@ def init() -> None:
 @click.option("--verbose", is_flag=True, help="Show debug-level detail.")
 def diagnose(
     time_window: int | None,
-    log_group: tuple[str, ...],
+    log_groups: tuple[str, ...],
     provider: str | None,
     output_json: bool,
     verbose: bool,
 ) -> None:
     """Run AI-powered incident diagnosis."""
-    console.print("[yellow]Diagnosis engine not yet implemented.[/yellow]")
-    sys.exit(1)
+    from autopsy.config import load_config
+    from autopsy.diagnosis import DiagnosisOrchestrator
+    from autopsy.renderers.json_out import JSONRenderer
+    from autopsy.renderers.terminal import TerminalRenderer
+
+    try:
+        cfg = load_config()
+    except AutopsyError as exc:
+        _handle_error(exc)
+
+    overrides = {}
+    if time_window is not None:
+        overrides["time_window"] = time_window
+    if log_groups:
+        overrides["log_groups"] = list(log_groups)
+    if provider is not None:
+        overrides["provider"] = provider
+
+    try:
+        orchestrator = DiagnosisOrchestrator(cfg)
+        result = orchestrator.run(
+            time_window=overrides.get("time_window"),
+            log_groups=overrides.get("log_groups"),
+            provider=overrides.get("provider"),
+        )
+    except AutopsyError as exc:
+        _handle_error(exc)
+
+    if output_json:
+        JSONRenderer().render(result)
+    else:
+        TerminalRenderer().render(result)
 
 
 # ---------------------------------------------------------------------------

--- a/autopsy/collectors/cloudwatch.py
+++ b/autopsy/collectors/cloudwatch.py
@@ -3,37 +3,129 @@
 Pulls error-level logs using the engineer's local AWS credentials.
 Implements a multi-stage reduction pipeline: query filter, deduplication,
 truncation, and token budgeting.
+
+Stage 1 (query-level filter): Handled by the Logs Insights query regex
+filtering for error|exception|fatal|panic|timeout|5xx — no code needed here.
 """
 
 from __future__ import annotations
 
-import hashlib
 import re
 import time
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 
 import boto3
-from botocore.exceptions import BotoCoreError, ClientError
+import botocore.exceptions
 from rich.console import Console
 
 from autopsy.collectors.base import BaseCollector, CollectedData
-from autopsy.utils.errors import AWSAuthError, AWSPermissionError, NoDataError
+from autopsy.utils.errors import (
+    AWSAuthError,
+    AWSPermissionError,
+    CollectorError,
+    NoDataError,
+)
 
 console = Console(stderr=True)
 
-DEFAULT_QUERY = """\
+# Logs Insights query: filter error-level messages, sort newest first, limit 200
+INSIGHTS_QUERY = """\
 fields @timestamp, @message, @logStream
 | filter @message like /(?i)(error|exception|fatal|panic|timeout|5\\d{2})/
 | sort @timestamp desc
 | limit 200
 """
 
+POLL_INTERVALS = (0.5, 1.0, 2.0, 4.0)  # seconds; then 4s until 30s total
+POLL_TIMEOUT_TOTAL = 30
+
+MAX_MESSAGE_CHARS = 500
+STACK_TRACE_MAX_FRAMES = 5
 TOKEN_BUDGET = 6000
-MAX_ENTRY_CHARS = 500
-MAX_STACK_FRAMES = 5
-QUERY_POLL_INTERVAL = 1.0
-QUERY_POLL_MAX_WAIT = 120.0
-CHARS_PER_TOKEN = 4  # conservative estimate in lieu of tiktoken dependency
+TOKEN_ESTIMATE_CHARS_PER_TOKEN = 4
+
+# Patterns for template extraction (dedup)
+_RE_UUID = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_RE_IP = re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+_RE_TIMESTAMP = re.compile(
+    r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?"
+)
+_RE_LONG_NUMBERS = re.compile(r"\b\d{4,}\b")
+_RE_HEX = re.compile(r"\b[0-9a-fA-F]{8,}\b")
+
+
+def _extract_template(message: str) -> str:
+    """Replace variable parts of log messages with placeholders for dedup.
+
+    Normalizes UUIDs, IPs, timestamps, long numbers, and hex strings so that
+    log lines that differ only by these values hash to the same template.
+
+    Args:
+        message: Raw log message.
+
+    Returns:
+        Normalized template string.
+    """
+    text = message
+    text = _RE_UUID.sub("<UUID>", text)
+    text = _RE_IP.sub("<IP>", text)
+    text = _RE_TIMESTAMP.sub("<TS>", text)
+    text = _RE_LONG_NUMBERS.sub("<NUM>", text)
+    text = _RE_HEX.sub("<HEX>", text)
+    return text
+
+
+def _truncate_message(msg: str) -> str:
+    """Cap message at MAX_MESSAGE_CHARS; trim stack traces to top 5 frames."""
+    lines = msg.split("\n")
+    # If it looks like a stack trace, keep first line (exception) + top 5 frames first
+    if len(lines) > 1 and ("Traceback" in lines[0] or "  File " in msg or " at " in msg):
+        first_line = lines[0]
+        frame_lines: list[str] = []
+        for line in lines[1:]:
+            stripped = line.strip()
+            if (stripped.startswith("File ") or stripped.startswith("at ")
+                    or (frame_lines and (stripped.startswith("  ") or not stripped))):
+                frame_lines.append(line)
+            else:
+                break
+        kept_frames = frame_lines[:STACK_TRACE_MAX_FRAMES]
+        msg = first_line + "\n" + "\n".join(kept_frames)
+        if len(frame_lines) > STACK_TRACE_MAX_FRAMES:
+            msg += "\n  ..."
+
+    if len(msg) <= MAX_MESSAGE_CHARS:
+        return msg
+    return msg[:MAX_MESSAGE_CHARS] + "…"
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token count: len/4 (no tiktoken dependency)."""
+    return max(1, len(text) // TOKEN_ESTIMATE_CHARS_PER_TOKEN)
+
+
+def _result_row_to_entry(row: list[dict]) -> dict:
+    """Convert a Logs Insights result row (list of field dicts) to our entry format."""
+    entry: dict = {}
+    for item in row:
+        k = item.get("field", "")
+        v = item.get("value", "")
+        if k == "@timestamp":
+            entry["@timestamp"] = v
+        elif k == "@message":
+            entry["@message"] = v
+        elif k == "@logStream":
+            entry["@logStream"] = v
+        elif k and not k.startswith("@"):
+            entry[k] = v
+    if "@message" not in entry:
+        entry["@message"] = ""
+    if "@timestamp" not in entry:
+        entry["@timestamp"] = ""
+    return entry
 
 
 class CloudWatchCollector(BaseCollector):
@@ -47,6 +139,9 @@ class CloudWatchCollector(BaseCollector):
     def validate_config(self, config: dict) -> bool:
         """Verify AWS credentials and CloudWatch permissions.
 
+        Uses describe_log_groups as a connectivity and auth check, and
+        verifies each configured log group exists.
+
         Args:
             config: The 'aws' section of AutopsyConfig.
 
@@ -55,23 +150,67 @@ class CloudWatchCollector(BaseCollector):
 
         Raises:
             AWSAuthError: On expired or invalid credentials.
-            AWSPermissionError: On missing logs:StartQuery permission.
+            AWSPermissionError: On missing logs:DescribeLogGroups permission.
         """
-        client = _make_client(config)
+        region = config.get("region", "us-east-1")
+        profile = config.get("profile")
+        log_groups = config.get("log_groups", [])
+
         try:
-            client.describe_log_groups(limit=1)
-        except ClientError as exc:
-            _raise_for_client_error(exc)
-        except BotoCoreError as exc:
+            session = boto3.Session(region_name=region, profile_name=profile)
+            client = session.client("logs")
+            for lg in log_groups:
+                found = False
+                paginator = client.get_paginator("describe_log_groups")
+                for page in paginator.paginate(logGroupNamePrefix=lg):
+                    for g in page.get("logGroups", []):
+                        if g.get("logGroupName") == lg:
+                            found = True
+                            break
+                    if found:
+                        break
+                if not found:
+                    raise AWSPermissionError(
+                        message=f"Log group not found: {lg}",
+                        hint=f"Check that {lg} exists and you have "
+                        "logs:DescribeLogGroups permission.",
+                    )
+        except botocore.exceptions.NoCredentialsError as exc:
             raise AWSAuthError(
-                message=f"AWS credential error: {exc}",
-                hint="Run 'aws configure' or check AWS_PROFILE.",
-                docs_url="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
+                message="AWS credentials not found",
+                hint="Run 'aws configure' or set AWS_PROFILE=<profile> and try again.\n"
+                "Docs: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
+            ) from exc
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("AccessDeniedException", "AccessDenied"):
+                raise AWSPermissionError(
+                    message="Missing required CloudWatch Logs permissions",
+                    hint="IAM role needs: logs:DescribeLogGroups, logs:StartQuery, "
+                    "logs:GetQueryResults.\nDocs: https://docs.aws.amazon.com/"
+                    "AmazonCloudWatch/latest/logs/iam-identity-based-access-control-cwl.html",
+                ) from exc
+            if code in ("ExpiredToken", "ExpiredTokenException"):
+                raise AWSAuthError(
+                    message="AWS credentials have expired",
+                    hint="Refresh your credentials: run 'aws sso login' or "
+                    "update your session token.",
+                ) from exc
+            err_msg = exc.response.get("Error", {}).get("Message", str(exc))
+            raise CollectorError(
+                message=f"AWS CloudWatch error: {err_msg}",
+                hint="Check your AWS region and IAM permissions.",
             ) from exc
         return True
 
     def collect(self, config: dict) -> CollectedData:
         """Pull error logs from CloudWatch and apply reduction pipeline.
+
+        Pipeline stages:
+        1. Query-level regex filter (~90% reduction) — in the Insights query.
+        2. Deduplication by message template (~60% reduction).
+        3. Truncation to 500 chars per entry, stack traces to 5 frames (~40%).
+        4. Token budget hard cap at 6000 tokens (FIFO eviction).
 
         Args:
             config: The 'aws' section of AutopsyConfig.
@@ -82,332 +221,174 @@ class CloudWatchCollector(BaseCollector):
         Raises:
             AWSAuthError: On credential failure.
             AWSPermissionError: On IAM permission issues.
+            CollectorError: On query timeout or failure.
             NoDataError: On zero results.
         """
-        client = _make_client(config)
-        time_window = config.get("time_window", 30)
+        region = config.get("region", "us-east-1")
+        profile = config.get("profile")
         log_groups = config.get("log_groups", [])
+        time_window = int(config.get("time_window", 30))
 
-        end_time = datetime.now(tz=timezone.utc)
-        start_time = end_time - timedelta(minutes=time_window)
+        end_ts = datetime.now(tz=timezone.utc)
+        start_ts = end_ts - timedelta(minutes=time_window)
+        start_unix = int(start_ts.timestamp())
+        end_unix = int(end_ts.timestamp())
 
-        raw_entries: list[dict] = []
+        try:
+            session = boto3.Session(region_name=region, profile_name=profile)
+            client = session.client("logs")
+        except botocore.exceptions.NoCredentialsError as exc:
+            raise AWSAuthError(
+                message="AWS credentials not found",
+                hint="Run 'aws configure' or set AWS_PROFILE=<profile> and try again.\n"
+                "Docs: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
+            ) from exc
+
+        all_rows: list[dict] = []
         for lg in log_groups:
-            raw_entries.extend(
-                _run_insights_query(client, lg, start_time, end_time)
-            )
+            with console.status(f"Querying CloudWatch log group: {lg}...", spinner="dots"):
+                try:
+                    query_id = client.start_query(
+                        logGroupNames=[lg],
+                        startTime=start_unix,
+                        endTime=end_unix,
+                        queryString=INSIGHTS_QUERY.strip(),
+                    ).get("queryId")
+                except botocore.exceptions.ClientError as exc:
+                    code = exc.response.get("Error", {}).get("Code", "")
+                    if code in ("AccessDeniedException", "AccessDenied"):
+                        raise AWSPermissionError(
+                            message="Missing required CloudWatch Logs permissions",
+                            hint="IAM role needs: logs:DescribeLogGroups, logs:StartQuery, "
+                            "logs:GetQueryResults.\nDocs: https://docs.aws.amazon.com/"
+                            "AmazonCloudWatch/latest/logs/iam-identity-based-access-control-cwl.html",
+                        ) from exc
+                    if code in ("ExpiredToken", "ExpiredTokenException"):
+                        raise AWSAuthError(
+                            message="AWS credentials have expired",
+                            hint="Refresh your credentials: run 'aws sso login' or "
+                            "update your session token.",
+                        ) from exc
+                    q_err = exc.response.get("Error", {}).get("Message", str(exc))
+                    raise CollectorError(
+                        message=f"CloudWatch query failed: {q_err}",
+                        hint="Check log group name and IAM permissions.",
+                    ) from exc
 
-        total_before = len(raw_entries)
+                if not query_id:
+                    raise CollectorError(
+                        message="CloudWatch start_query did not return a queryId",
+                        hint="Retry or check AWS service status.",
+                    )
 
-        if total_before == 0:
+                # Poll with exponential backoff; max 30s total
+                elapsed = 0.0
+                for _idx, interval in enumerate(POLL_INTERVALS):
+                    if elapsed >= POLL_TIMEOUT_TOTAL:
+                        break
+                    time.sleep(interval)
+                    elapsed += interval
+                    resp = client.get_query_results(queryId=query_id)
+                    status = resp.get("status", "")
+                    if status == "Complete":
+                        for row in resp.get("results", []):
+                            all_rows.append(_result_row_to_entry(row))
+                        break
+                    if status == "Failed":
+                        raise CollectorError(
+                            message="CloudWatch Logs Insights query failed",
+                            hint="Check your query and log group; try a smaller time window.",
+                        )
+                    if status == "Cancelled":
+                        raise CollectorError(
+                            message="CloudWatch query was cancelled",
+                            hint="Retry the diagnosis.",
+                        )
+                else:
+                    # More polls at 4s until timeout
+                    while elapsed < POLL_TIMEOUT_TOTAL:
+                        time.sleep(4.0)
+                        elapsed += 4.0
+                        resp = client.get_query_results(queryId=query_id)
+                        status = resp.get("status", "")
+                        if status == "Complete":
+                            for row in resp.get("results", []):
+                                all_rows.append(_result_row_to_entry(row))
+                            break
+                        if status == "Failed":
+                            raise CollectorError(
+                                message="CloudWatch Logs Insights query failed",
+                                hint="Check your query and log group; try a smaller time window.",
+                            )
+                        if status == "Cancelled":
+                            raise CollectorError(
+                                message="CloudWatch query was cancelled",
+                                hint="Retry the diagnosis.",
+                            )
+                    else:
+                        raise CollectorError(
+                            message="CloudWatch query timed out (30s)",
+                            hint="Try a smaller time window or fewer log groups.",
+                        )
+
+        if not all_rows:
             raise NoDataError(
-                message=f"No error logs found in the last {time_window} minutes.",
-                hint=(
-                    "Check that your log groups are correct and contain recent "
-                    "error-level messages. Try increasing --time-window."
-                ),
+                message=f"No error-level logs found in the last {time_window} minutes",
+                hint="Verify your log_groups in ~/.autopsy/config.yaml point to active log groups.",
             )
 
-        # --- Stage 2: Deduplication ---
-        entries = _deduplicate(raw_entries)
+        # Stage 2: Deduplication by template
+        template_to_entry: dict[str, dict] = {}
+        for entry in all_rows:
+            msg = entry.get("@message", "")
+            template = _extract_template(msg)
+            key = sha256(template.encode("utf-8")).hexdigest()
+            if key in template_to_entry:
+                template_to_entry[key]["occurrences"] = (
+                    template_to_entry[key].get("occurrences", 1) + 1
+                )
+            else:
+                entry["occurrences"] = 1
+                template_to_entry[key] = entry
 
-        # --- Stage 3: Truncation ---
-        entries = [_truncate_entry(e) for e in entries]
+        deduped: list[dict] = list(template_to_entry.values())
 
-        # --- Stage 4: Token budget ---
-        entries, was_truncated = _apply_token_budget(entries)
+        # Stage 3: Truncation
+        for entry in deduped:
+            msg = entry.get("@message", "")
+            entry["@message"] = _truncate_message(msg)
 
+        # Stage 4: Token budget
+        truncated = False
+        total_tokens = sum(
+            _estimate_tokens(e.get("@message", "")) + _estimate_tokens(e.get("@timestamp", ""))
+            for e in deduped
+        )
+        if total_tokens > TOKEN_BUDGET:
+            truncated = True
+            current: list[dict] = []
+            current_tokens = 0
+            for entry in reversed(deduped):  # FIFO = keep newest, evict oldest
+                t = _estimate_tokens(entry.get("@message", "")) + _estimate_tokens(
+                    entry.get("@timestamp", "")
+                )
+                if current_tokens + t <= TOKEN_BUDGET:
+                    current.append(entry)
+                    current_tokens += t
+                else:
+                    break
+            deduped = list(reversed(current))
+
+        raw_query = (
+            f"Logs Insights filter (error|exception|fatal|panic|timeout|5xx); "
+            f"window={time_window}m; groups={len(log_groups)}"
+        )
         return CollectedData(
             source="cloudwatch",
             data_type="logs",
-            entries=entries,
-            time_range=(start_time, end_time),
-            raw_query=DEFAULT_QUERY.strip(),
-            entry_count=total_before,
-            truncated=was_truncated or len(entries) < total_before,
+            entries=deduped,
+            time_range=(start_ts, end_ts),
+            raw_query=raw_query,
+            entry_count=len(all_rows),
+            truncated=truncated,
         )
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_client(config: dict) -> boto3.client:
-    """Build a CloudWatch Logs boto3 client from config.
-
-    Args:
-        config: The 'aws' section dict.
-
-    Returns:
-        boto3 CloudWatch Logs client.
-    """
-    session_kwargs: dict = {}
-    if config.get("profile"):
-        session_kwargs["profile_name"] = config["profile"]
-
-    session = boto3.Session(**session_kwargs)
-    return session.client("logs", region_name=config.get("region", "us-east-1"))
-
-
-def _run_insights_query(
-    client: boto3.client,
-    log_group: str,
-    start: datetime,
-    end: datetime,
-) -> list[dict]:
-    """Execute a CloudWatch Logs Insights query and poll for results.
-
-    Args:
-        client: boto3 logs client.
-        log_group: CloudWatch log group name.
-        start: Query start time (UTC).
-        end: Query end time (UTC).
-
-    Returns:
-        List of raw result dicts with @timestamp, @message, @logStream.
-
-    Raises:
-        AWSAuthError: On credential failure.
-        AWSPermissionError: On missing IAM permissions.
-    """
-    try:
-        response = client.start_query(
-            logGroupName=log_group,
-            startTime=int(start.timestamp()),
-            endTime=int(end.timestamp()),
-            queryString=DEFAULT_QUERY,
-        )
-    except ClientError as exc:
-        _raise_for_client_error(exc)
-
-    query_id = response["queryId"]
-    return _poll_query(client, query_id)
-
-
-def _poll_query(client: boto3.client, query_id: str) -> list[dict]:
-    """Poll a Logs Insights query until complete.
-
-    Args:
-        client: boto3 logs client.
-        query_id: ID from start_query response.
-
-    Returns:
-        Flattened list of result entry dicts.
-    """
-    elapsed = 0.0
-    while elapsed < QUERY_POLL_MAX_WAIT:
-        result = client.get_query_results(queryId=query_id)
-        status = result.get("status", "")
-        if status == "Complete":
-            return _flatten_results(result.get("results", []))
-        if status in ("Failed", "Cancelled", "Timeout"):
-            return []
-        time.sleep(QUERY_POLL_INTERVAL)
-        elapsed += QUERY_POLL_INTERVAL
-    return []
-
-
-def _flatten_results(raw_results: list[list[dict]]) -> list[dict]:
-    """Convert Logs Insights result rows into flat dicts.
-
-    Each row is a list of {field, value} dicts. Flatten to {field: value}.
-
-    Args:
-        raw_results: Raw results from get_query_results.
-
-    Returns:
-        List of flat entry dicts.
-    """
-    entries = []
-    for row in raw_results:
-        entry: dict = {}
-        for field_obj in row:
-            key = field_obj.get("field", "")
-            val = field_obj.get("value", "")
-            if key and not key.startswith("@ptr"):
-                entry[key] = val
-        if entry:
-            entries.append(entry)
-    return entries
-
-
-def _raise_for_client_error(exc: ClientError) -> None:
-    """Map a boto3 ClientError to the appropriate Autopsy exception.
-
-    Args:
-        exc: The caught ClientError.
-
-    Raises:
-        AWSAuthError: On auth-related error codes.
-        AWSPermissionError: On access-denied error codes.
-    """
-    code = exc.response.get("Error", {}).get("Code", "")
-
-    if code in (
-        "ExpiredTokenException",
-        "UnrecognizedClientException",
-        "InvalidSignatureException",
-        "AuthFailure",
-    ):
-        raise AWSAuthError(
-            message=f"AWS authentication failed: {code}",
-            hint="Run 'aws configure' or set AWS_PROFILE and try again.",
-            docs_url="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
-        ) from exc
-
-    if code in ("AccessDeniedException", "AccessDenied"):
-        raise AWSPermissionError(
-            message=f"AWS permission denied: {code}",
-            hint=(
-                "Ensure your IAM user/role has logs:StartQuery, "
-                "logs:GetQueryResults, and logs:DescribeLogGroups permissions."
-            ),
-            docs_url="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/permissions-reference-cwl.html",
-        ) from exc
-
-    raise AWSAuthError(
-        message=f"AWS API error ({code}): {exc}",
-        hint="Check your AWS credentials and region configuration.",
-    ) from exc
-
-
-# ---------------------------------------------------------------------------
-# Reduction pipeline
-# ---------------------------------------------------------------------------
-
-
-_TEMPLATE_RE = re.compile(
-    r"(0x[0-9a-fA-F]+|"          # hex addresses
-    r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[^\s]*|"  # timestamps
-    r"\b[0-9a-f]{8,}\b|"         # long hex ids
-    r"\d+)"                       # any numeric sequence
-)
-
-
-def _template_hash(message: str) -> str:
-    """Produce a hash of the message with variable parts normalized.
-
-    Replaces numbers, hex addresses, timestamps, and UUIDs with
-    placeholders so structurally identical messages map to the same hash.
-
-    Args:
-        message: Raw log message string.
-
-    Returns:
-        Hex digest of the normalized template.
-    """
-    normalized = _TEMPLATE_RE.sub("<*>", message)
-    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
-
-
-def _deduplicate(entries: list[dict]) -> list[dict]:
-    """Stage 2: Deduplicate by message template, keeping 1 instance + count.
-
-    Args:
-        entries: Raw log entries from the query.
-
-    Returns:
-        Deduplicated entries with an 'occurrences' count field.
-    """
-    seen: dict[str, dict] = {}
-    counts: dict[str, int] = {}
-
-    for entry in entries:
-        msg = entry.get("@message", "")
-        tmpl = _template_hash(msg)
-        if tmpl not in seen:
-            seen[tmpl] = entry
-            counts[tmpl] = 1
-        else:
-            counts[tmpl] += 1
-
-    result = []
-    for tmpl, entry in seen.items():
-        entry_copy = dict(entry)
-        entry_copy["occurrences"] = counts[tmpl]
-        result.append(entry_copy)
-    return result
-
-
-def _truncate_stack_trace(message: str) -> str:
-    """Trim stack traces to the top N frames.
-
-    Args:
-        message: Log message potentially containing a stack trace.
-
-    Returns:
-        Truncated message with at most MAX_STACK_FRAMES stack frames.
-    """
-    lines = message.split("\n")
-    frame_indices: list[int] = []
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith(("at ", "File ", "Traceback", "  File ")):
-            frame_indices.append(i)
-
-    if len(frame_indices) <= MAX_STACK_FRAMES:
-        return message
-
-    keep_up_to = frame_indices[MAX_STACK_FRAMES - 1]
-    kept = lines[: keep_up_to + 1]
-    omitted = len(frame_indices) - MAX_STACK_FRAMES
-    kept.append(f"  ... ({omitted} more frames omitted)")
-    return "\n".join(kept)
-
-
-def _truncate_entry(entry: dict) -> dict:
-    """Stage 3: Truncate a single entry's message to MAX_ENTRY_CHARS.
-
-    Also trims stack traces to top MAX_STACK_FRAMES frames.
-
-    Args:
-        entry: A log entry dict with '@message' key.
-
-    Returns:
-        Entry with truncated message.
-    """
-    msg = entry.get("@message", "")
-    msg = _truncate_stack_trace(msg)
-    if len(msg) > MAX_ENTRY_CHARS:
-        msg = msg[:MAX_ENTRY_CHARS] + "…"
-    result = dict(entry)
-    result["@message"] = msg
-    return result
-
-
-def _estimate_tokens(entries: list[dict]) -> int:
-    """Estimate token count for a list of entries.
-
-    Uses a simple character-based heuristic (1 token ~ 4 chars).
-
-    Args:
-        entries: Log entries to measure.
-
-    Returns:
-        Estimated token count.
-    """
-    total_chars = sum(len(str(e)) for e in entries)
-    return total_chars // CHARS_PER_TOKEN
-
-
-def _apply_token_budget(entries: list[dict]) -> tuple[list[dict], bool]:
-    """Stage 4: Evict oldest entries (FIFO) until under TOKEN_BUDGET.
-
-    Args:
-        entries: Deduplicated and truncated log entries.
-
-    Returns:
-        (entries within budget, whether any were evicted).
-    """
-    if _estimate_tokens(entries) <= TOKEN_BUDGET:
-        return entries, False
-
-    kept: list[dict] = []
-    for entry in entries:
-        candidate = [*kept, entry]
-        if _estimate_tokens(candidate) > TOKEN_BUDGET:
-            break
-        kept.append(entry)
-
-    return kept, True

--- a/autopsy/collectors/github.py
+++ b/autopsy/collectors/github.py
@@ -361,6 +361,6 @@ def _find_pr_for_commit(commit) -> dict | None:
                 "body": body,
                 "merged_at": pr.merged_at.isoformat() if pr.merged_at else None,
             }
-    except (GithubException, Exception):
+    except GithubException:
         return None
     return None

--- a/autopsy/diagnosis.py
+++ b/autopsy/diagnosis.py
@@ -7,11 +7,22 @@ the structured result. Rendering is the caller's responsibility.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
+
+from autopsy.ai.engine import AIEngine
+from autopsy.collectors.cloudwatch import CloudWatchCollector
+from autopsy.collectors.github import GitHubCollector
+from autopsy.config import AutopsyConfig  # noqa: TC001 — used at runtime for __init__
 
 if TYPE_CHECKING:
     from autopsy.ai.models import DiagnosisResult
-    from autopsy.config import AutopsyConfig
+    from autopsy.collectors.base import CollectedData
+
+_AI_KEY_ENV_BY_PROVIDER: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
 
 
 class DiagnosisOrchestrator:
@@ -25,14 +36,25 @@ class DiagnosisOrchestrator:
         """
         self.config = config
 
-    def run(self) -> DiagnosisResult:
+    def run(
+        self,
+        *,
+        time_window: int | None = None,
+        log_groups: list[str] | None = None,
+        provider: str | None = None,
+    ) -> DiagnosisResult:
         """Execute the full diagnosis pipeline.
 
         Steps:
-        1. Validate config and credentials
-        2. Collect data from all registered collectors
-        3. Pass collected data to the AI engine
-        4. Return DiagnosisResult (rendering is caller's job)
+        1. Build effective config (apply overrides)
+        2. Validate collector and AI credentials
+        3. Collect data from CloudWatch and GitHub
+        4. Call AI engine and return DiagnosisResult
+
+        Args:
+            time_window: Override config time window (minutes).
+            log_groups: Override config log groups (replaces list).
+            provider: Override AI provider ('anthropic' | 'openai').
 
         Returns:
             Structured DiagnosisResult from the AI engine.
@@ -42,4 +64,48 @@ class DiagnosisOrchestrator:
             CollectorError: On data collection failure.
             AIError: On AI provider failure.
         """
-        raise NotImplementedError
+        # Effective config: start from loaded config, apply overrides
+        aws_dict = self.config.aws.model_dump()
+        if time_window is not None:
+            aws_dict["time_window"] = time_window
+        if log_groups is not None:
+            aws_dict["log_groups"] = list(log_groups)
+
+        ai_provider = provider if provider is not None else self.config.ai.provider
+        api_key_env = _AI_KEY_ENV_BY_PROVIDER.get(
+            ai_provider, self.config.ai.api_key_env
+        )
+        api_key = os.environ.get(api_key_env, "")
+        if not api_key:
+            from autopsy.utils.errors import AIAuthError
+
+            raise AIAuthError(
+                message=f"AI API key env var '{api_key_env}' is not set.",
+                hint=f"Export {api_key_env} before running diagnose.",
+            )
+
+        # Validate collectors
+        cw = CloudWatchCollector()
+        gh = GitHubCollector()
+        cw.validate_config(aws_dict)
+        gh.validate_config(self.config.github.model_dump())
+
+        # Collect
+        collected: list[CollectedData] = []
+        collected.append(cw.collect(aws_dict))
+        collected.append(gh.collect(self.config.github.model_dump()))
+
+        # AI engine
+        model = (
+            self.config.ai.model
+            if ai_provider == self.config.ai.provider
+            else ("gpt-4o" if ai_provider == "openai" else self.config.ai.model)
+        )
+        engine = AIEngine(
+            provider=ai_provider,
+            model=model,
+            api_key=api_key,
+            max_tokens=self.config.ai.max_tokens,
+            temperature=self.config.ai.temperature,
+        )
+        return engine.diagnose(collected)

--- a/autopsy/renderers/json_out.py
+++ b/autopsy/renderers/json_out.py
@@ -5,12 +5,10 @@ Outputs DiagnosisResult as formatted JSON to stdout.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import sys
 
+from autopsy.ai.models import DiagnosisResult  # noqa: TC001 — used at runtime for render()
 from autopsy.renderers.terminal import BaseRenderer
-
-if TYPE_CHECKING:
-    from autopsy.ai.models import DiagnosisResult
 
 
 class JSONRenderer(BaseRenderer):
@@ -22,4 +20,6 @@ class JSONRenderer(BaseRenderer):
         Args:
             result: Structured diagnosis from the AI engine.
         """
-        raise NotImplementedError
+        sys.stdout.write(result.model_dump_json(indent=2))
+        sys.stdout.write("\n")
+        sys.stdout.flush()

--- a/autopsy/renderers/terminal.py
+++ b/autopsy/renderers/terminal.py
@@ -1,16 +1,42 @@
 """Rich terminal renderer for diagnosis output.
 
 Produces Slack-pasteable panels: Root Cause, Correlated Deploy,
-Suggested Fix, and Timeline.
+Suggested Fix, and Timeline. Clean when copied as plain text.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from autopsy.ai.models import DiagnosisResult
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from autopsy.ai.models import DiagnosisResult  # noqa: TC001 — used at runtime for render()
+
+console = Console()
+
+
+def _confidence_style(confidence: float) -> str:
+    """Return Rich style for confidence level (red < 0.5, yellow 0.5–0.75, green > 0.75)."""
+    if confidence < 0.5:
+        return "red"
+    if confidence <= 0.75:
+        return "yellow"
+    return "green"
+
+
+def _category_style(category: str) -> str:
+    """Return Rich style for category tag."""
+    styles = {
+        "code_change": "bold blue",
+        "config_change": "bold magenta",
+        "infra": "bold cyan",
+        "dependency": "bold yellow",
+        "traffic": "bold white",
+        "unknown": "dim",
+    }
+    return styles.get(category, "dim")
 
 
 class BaseRenderer(ABC):
@@ -26,15 +52,112 @@ class BaseRenderer(ABC):
 
 
 class TerminalRenderer(BaseRenderer):
-    """Renders DiagnosisResult as Rich panels to stdout."""
+    """Renders DiagnosisResult as Rich panels to stdout.
+
+    Four panels: Root Cause (with confidence bar), Correlated Deploy,
+    Suggested Fix, Timeline table. Design is Slack-pasteable.
+    """
 
     def render(self, result: DiagnosisResult) -> None:
         """Render diagnosis as colored Rich panels.
 
-        Panels: Root Cause (with confidence bar), Correlated Deploy,
-        Suggested Fix, Timeline table. Colors keyed to confidence level.
-
         Args:
             result: Structured diagnosis from the AI engine.
         """
-        raise NotImplementedError
+        # Panel 1: Root Cause — summary, category tag, confidence bar, evidence bullets
+        rc = result.root_cause
+        conf_style = _confidence_style(rc.confidence)
+        cat_style = _category_style(rc.category)
+
+        root_lines: list[str] = []
+        root_lines.append(rc.summary)
+        root_lines.append("")
+        root_lines.append(f"Category: [{cat_style}]{rc.category}[/]")
+        root_lines.append(f"Confidence: [{conf_style}]{rc.confidence:.0%}[/]")
+        # Confidence bar (10 chars)
+        filled = int(rc.confidence * 10)
+        bar = "█" * filled + "░" * (10 - filled)
+        root_lines.append(f"[{conf_style}]{bar}[/]")
+        if rc.evidence:
+            root_lines.append("")
+            root_lines.append("Evidence:")
+            for line in rc.evidence:
+                root_lines.append(f"  • {line}")
+
+        console.print(
+            Panel(
+                "\n".join(root_lines),
+                title="[bold]Root Cause[/bold]",
+                border_style="blue",
+                padding=(0, 1),
+            )
+        )
+
+        # Panel 2: Correlated Deploy
+        cd = result.correlated_deploy
+        deploy_lines: list[str] = []
+        if cd.commit_sha:
+            deploy_lines.append(f"Commit: {cd.commit_sha}")
+        if cd.author:
+            deploy_lines.append(f"Author: {cd.author}")
+        if cd.pr_title:
+            deploy_lines.append(f"PR: {cd.pr_title}")
+        if cd.changed_files:
+            deploy_lines.append("Changed files:")
+            for f in cd.changed_files:
+                deploy_lines.append(f"  • {f}")
+        if not deploy_lines:
+            deploy_lines.append("No deploy correlated.")
+
+        console.print(
+            Panel(
+                "\n".join(deploy_lines),
+                title="[bold]Correlated Deploy[/bold]",
+                border_style="cyan",
+                padding=(0, 1),
+            )
+        )
+
+        # Panel 3: Suggested Fix
+        sf = result.suggested_fix
+        fix_lines = [
+            "[bold]Immediate:[/bold]",
+            sf.immediate,
+            "",
+            "[bold]Long-term:[/bold]",
+            sf.long_term,
+        ]
+        console.print(
+            Panel(
+                "\n".join(fix_lines),
+                title="[bold]Suggested Fix[/bold]",
+                border_style="green",
+                padding=(0, 1),
+            )
+        )
+
+        # Panel 4: Timeline table
+        table = Table(
+            title="Timeline",
+            show_header=True,
+            header_style="bold",
+            border_style="white",
+            box=None,
+        )
+        table.add_column("Time", style="dim", no_wrap=True)
+        table.add_column("Event")
+        for ev in result.timeline:
+            table.add_row(ev.time, ev.event)
+        if not result.timeline:
+            table.add_row("—", "No events.")
+        console.print(Panel(table, border_style="white", padding=(0, 1)))
+
+        if result.raw_response:
+            console.print(
+                Panel(
+                    result.raw_response,
+                    title="[dim]Raw AI response (parse fallback)[/dim]",
+                    border_style="dim",
+                    padding=(0, 1),
+                )
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = ["autopsy"]
 [project]
 name = "autopsy-cli"
 version = "0.1.0"
-description = "AI-powered incident diagnosis CLI. Diagnose production incidents in 30 seconds."
+description = "AI-powered incident diagnosis for engineering teams. Pull logs and deploys, get a structured root cause in 30 seconds."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
@@ -21,6 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,6 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "Topic :: Software Development :: Quality Assurance",
 ]
+keywords = ["incident", "diagnosis", "root-cause", "cloudwatch", "github", "ai", "llm"]
 dependencies = [
     "click>=8.0",
     "boto3>=1.28",

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,355 +1,499 @@
-"""Tests for autopsy.collectors.cloudwatch — CloudWatch collector."""
+"""Tests for autopsy.collectors.cloudwatch — CloudWatch Logs Insights collector."""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
 import pytest
-from botocore.exceptions import ClientError
+import botocore.exceptions
 
 from autopsy.collectors.cloudwatch import (
     CloudWatchCollector,
-    _apply_token_budget,
-    _deduplicate,
-    _estimate_tokens,
-    _template_hash,
-    _truncate_entry,
-    _truncate_stack_trace,
+    _extract_template,
+    _result_row_to_entry,
+    _truncate_message,
 )
-from autopsy.utils.errors import AWSAuthError, AWSPermissionError, NoDataError
+from autopsy.collectors.base import CollectedData
+from autopsy.utils.errors import (
+    AWSAuthError,
+    AWSPermissionError,
+    CollectorError,
+    NoDataError,
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _aws_config() -> dict:
-    """Minimal AWS config for testing."""
-    return {
-        "region": "us-east-1",
-        "log_groups": ["/aws/lambda/my-api"],
-        "time_window": 30,
+
+def _aws_config(
+    region: str = "us-east-1",
+    log_groups: list[str] | None = None,
+    time_window: int = 30,
+    profile: str | None = None,
+) -> dict:
+    """Build minimal AWS config dict for collector."""
+    if log_groups is None:
+        log_groups = ["/aws/lambda/my-api"]
+    out = {
+        "region": region,
+        "log_groups": log_groups,
+        "time_window": time_window,
     }
+    if profile is not None:
+        out["profile"] = profile
+    return out
 
 
-def _make_log_row(timestamp: str, message: str, stream: str = "stream-1") -> list[dict]:
-    """Build a Logs Insights result row."""
+def _insights_row(timestamp: str = "2026-03-06T10:00:00.000Z", message: str = "ERROR") -> list[dict]:
+    """One Logs Insights result row (list of field/value dicts)."""
     return [
         {"field": "@timestamp", "value": timestamp},
         {"field": "@message", "value": message},
-        {"field": "@logStream", "value": stream},
-        {"field": "@ptr", "value": "ptr-ignore-me"},
+        {"field": "@logStream", "value": "stream1"},
     ]
 
 
-# ---------------------------------------------------------------------------
-# Template hashing
-# ---------------------------------------------------------------------------
+def _mock_logs_client(
+    describe_pages: list[dict] | None = None,
+    start_query_id: str = "query-123",
+    get_results_status: str = "Complete",
+    get_results_rows: list[list[dict]] | None = None,
+    get_results_side_effect=None,
+):
+    """Build a mock logs client with describe_log_groups and query behavior."""
+    if describe_pages is None:
+        describe_pages = [{"logGroups": [{"logGroupName": "/aws/lambda/my-api"}]}]
+    if get_results_rows is None:
+        get_results_rows = [_insights_row(message="ERROR: connection refused")]
 
-
-class TestTemplateHash:
-    """Message template normalization for dedup."""
-
-    def test_identical_messages_same_hash(self) -> None:
-        assert _template_hash("ERROR in handler") == _template_hash("ERROR in handler")
-
-    def test_different_numbers_same_hash(self) -> None:
-        h1 = _template_hash("Timeout after 3000ms on request 42")
-        h2 = _template_hash("Timeout after 5000ms on request 99")
-        assert h1 == h2
-
-    def test_different_timestamps_same_hash(self) -> None:
-        h1 = _template_hash("Error at 2026-03-06T10:00:00Z in handler")
-        h2 = _template_hash("Error at 2026-03-06T12:30:00Z in handler")
-        assert h1 == h2
-
-    def test_different_hex_ids_same_hash(self) -> None:
-        h1 = _template_hash("Request abcdef12 failed")
-        h2 = _template_hash("Request 12345678 failed")
-        assert h1 == h2
-
-    def test_structurally_different_messages(self) -> None:
-        h1 = _template_hash("NullPointerException in handler")
-        h2 = _template_hash("TimeoutException in scheduler")
-        assert h1 != h2
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = iter(describe_pages)
+    client.get_paginator.return_value = paginator
+    client.start_query.return_value = {"queryId": start_query_id}
+    if get_results_side_effect is not None:
+        client.get_query_results.side_effect = get_results_side_effect
+    else:
+        client.get_query_results.return_value = {
+            "status": get_results_status,
+            "results": get_results_rows,
+        }
+    return client
 
 
 # ---------------------------------------------------------------------------
-# Deduplication (Stage 2)
+# _extract_template
 # ---------------------------------------------------------------------------
 
 
-class TestDeduplicate:
-    """Stage 2: hash-based dedup with occurrence counting."""
+class TestExtractTemplate:
+    """Template extraction for deduplication."""
 
-    def test_unique_messages_kept(self) -> None:
-        entries = [
-            {"@message": "Error A", "@timestamp": "t1"},
-            {"@message": "Error B", "@timestamp": "t2"},
+    def test_uuid_replaced(self) -> None:
+        msg = "Request id 550e8400-e29b-41d4-a716-446655440000 failed"
+        assert "<UUID>" in _extract_template(msg)
+        assert "550e8400" not in _extract_template(msg)
+
+    def test_ip_replaced(self) -> None:
+        msg = "Connection from 192.168.1.100 refused"
+        assert "<IP>" in _extract_template(msg)
+        assert "192.168.1.100" not in _extract_template(msg)
+
+    def test_timestamp_replaced(self) -> None:
+        msg = "Event at 2026-03-06T10:00:00.000Z"
+        assert "<TS>" in _extract_template(msg)
+        assert "2026-03-06" not in _extract_template(msg)
+
+    def test_long_numbers_replaced(self) -> None:
+        msg = "Order 12345678 failed"
+        assert "<NUM>" in _extract_template(msg)
+        assert "12345678" not in _extract_template(msg)
+
+    def test_hex_replaced(self) -> None:
+        msg = "Hash abcdef0123456789 invalid"
+        assert "<HEX>" in _extract_template(msg)
+        assert "abcdef0123456789" not in _extract_template(msg)
+
+    def test_short_numbers_unchanged(self) -> None:
+        msg = "Retry 3 of 5"
+        result = _extract_template(msg)
+        assert "3" in result and "5" in result
+
+    def test_placeholder_only_diff(self) -> None:
+        a = _extract_template("Error at 2026-03-06T10:00:00Z id 12345")
+        b = _extract_template("Error at 2026-03-07T11:00:00Z id 67890")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestCollectHappyPath:
+    """Collect returns valid CollectedData with mocked boto3."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_collected_data_shape(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = _mock_logs_client(
+            get_results_rows=[
+                _insights_row(message="ERROR: NullPointerException"),
+                _insights_row(timestamp="2026-03-06T10:01:00.000Z", message="ERROR: timeout"),
+            ],
+        )
+        mock_session.return_value.client.return_value = client
+
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
+
+        assert isinstance(result, CollectedData)
+        assert result.source == "cloudwatch"
+        assert result.data_type == "logs"
+        assert result.entry_count == 2
+        assert len(result.entries) == 2
+        assert result.time_range[0] <= result.time_range[1]
+        assert "error|exception" in result.raw_query.lower() or "Logs Insights" in result.raw_query
+        assert result.entries[0].get("@message") == "ERROR: NullPointerException"
+        assert result.entries[0].get("@timestamp")
+        assert result.entries[0].get("occurrences", 1) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dedup pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestDedupPipeline:
+    """Stage 2: duplicate messages merged with occurrences count."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_duplicates_merged_with_occurrences(
+        self, mock_session: MagicMock
+    ) -> None:
+        # 20 rows: 5 distinct message structures, 4 copies each (same template, different values)
+        templates = [
+            "ERROR: request 10000 failed at 2026-03-06T10:00:00Z",
+            "ERROR: connection from 192.168.1.1 refused",
+            "ERROR: timeout after 5000 ms",
+            "ERROR: code 500 exception in handler",
+            "ERROR: id abcdef0123456789 not found",
         ]
-        result = _deduplicate(entries)
-        assert len(result) == 2
+        rows = []
+        for msg in templates:
+            for _ in range(4):
+                rows.append(_insights_row(message=msg))
+        # One more with a different structure (so 6th unique template)
+        rows.append(_insights_row(message="FATAL: panic in goroutine"))
 
-    def test_duplicates_collapsed_with_count(self) -> None:
-        entries = [
-            {"@message": "Timeout after 100ms", "@timestamp": "t1"},
-            {"@message": "Timeout after 200ms", "@timestamp": "t2"},
-            {"@message": "Timeout after 300ms", "@timestamp": "t3"},
-        ]
-        result = _deduplicate(entries)
-        assert len(result) == 1
-        assert result[0]["occurrences"] == 3
+        client = _mock_logs_client(get_results_rows=rows)
+        mock_session.return_value.client.return_value = client
 
-    def test_mixed_messages(self) -> None:
-        entries = [
-            {"@message": "Timeout after 100ms", "@timestamp": "t1"},
-            {"@message": "NullPointer in handler", "@timestamp": "t2"},
-            {"@message": "Timeout after 200ms", "@timestamp": "t3"},
-        ]
-        result = _deduplicate(entries)
-        assert len(result) == 2
-        timeout_entry = next(e for e in result if "Timeout" in e["@message"])
-        assert timeout_entry["occurrences"] == 2
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
 
-    def test_empty_input(self) -> None:
-        assert _deduplicate([]) == []
+        # 5 templates (4 copies each) + 1 unique = 6 unique entries, 21 total rows
+        assert result.entry_count == 21
+        assert len(result.entries) == 6
+        occurrences = [e.get("occurrences", 1) for e in result.entries]
+        assert max(occurrences) >= 2
+        assert sum(occurrences) == 21
 
 
 # ---------------------------------------------------------------------------
-# Truncation (Stage 3)
+# Truncation
 # ---------------------------------------------------------------------------
 
 
 class TestTruncation:
-    """Stage 3: per-entry truncation and stack trace trimming."""
+    """Stage 3: messages capped at 500 chars; stack traces to 5 frames."""
 
-    def test_short_message_unchanged(self) -> None:
-        entry = {"@message": "short error"}
-        result = _truncate_entry(entry)
-        assert result["@message"] == "short error"
-
-    def test_long_message_truncated(self) -> None:
-        entry = {"@message": "x" * 1000}
-        result = _truncate_entry(entry)
-        assert len(result["@message"]) == 501  # 500 + ellipsis char
+    def test_truncate_message_cap(self) -> None:
+        long_msg = "x" * 1000
+        out = _truncate_message(long_msg)
+        assert len(out) <= 501  # 500 + "…"
+        assert out.endswith("…")
 
     def test_stack_trace_trimmed(self) -> None:
-        frames = "\n".join(
-            f"  at com.example.Class{i}.method(Class{i}.java:{i})"
-            for i in range(20)
+        lines = [
+            "Traceback (most recent call last):",
+            "  File \"/app/handler.py\", line 42, in run",
+            "    raise ValueError('bad')",
+            "  File \"/app/lib.py\", line 1, in helper",
+            "  File \"/app/lib.py\", line 2, in helper",
+            "  File \"/app/lib.py\", line 3, in helper",
+            "  File \"/app/lib.py\", line 4, in helper",
+            "  File \"/app/lib.py\", line 5, in helper",
+        ]
+        msg = "\n".join(lines)
+        out = _truncate_message(msg)
+        # Should keep first line + at most 5 "  File " frame lines
+        frame_count = out.count("  File ")
+        assert frame_count <= 5
+        assert "Traceback" in out or "ValueError" in out
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_collect_truncates_long_messages(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = _mock_logs_client(
+            get_results_rows=[
+                _insights_row(message="A" * 1200),
+            ],
         )
-        msg = f"java.lang.NullPointerException\n{frames}"
-        result = _truncate_stack_trace(msg)
-        at_lines = [line for line in result.split("\n") if line.strip().startswith("at ")]
-        assert len(at_lines) == 5
+        mock_session.return_value.client.return_value = client
 
-    def test_short_stack_not_trimmed(self) -> None:
-        frames = "\n".join(f"  at Class{i}.method()" for i in range(3))
-        msg = f"Error\n{frames}"
-        result = _truncate_stack_trace(msg)
-        assert "omitted" not in result
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
 
-    def test_original_entry_not_mutated(self) -> None:
-        entry = {"@message": "x" * 1000, "@timestamp": "t1"}
-        _truncate_entry(entry)
-        assert len(entry["@message"]) == 1000
+        assert len(result.entries) == 1
+        assert len(result.entries[0]["@message"]) <= 501
 
 
 # ---------------------------------------------------------------------------
-# Token budget (Stage 4)
+# Token budget
 # ---------------------------------------------------------------------------
 
 
 class TestTokenBudget:
-    """Stage 4: FIFO eviction to stay within token budget."""
+    """Stage 4: hard cap at 6000 tokens; truncated=True when eviction occurs."""
 
-    def test_under_budget_no_eviction(self) -> None:
-        entries = [{"@message": "short"}]
-        result, truncated = _apply_token_budget(entries)
-        assert result == entries
-        assert truncated is False
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_over_budget_sets_truncated(
+        self, mock_session: MagicMock
+    ) -> None:
+        # 100 unique templates (different "type XX") so no dedup; ~300 chars each ≈ 7500 tokens
+        rows = [
+            _insights_row(
+                message=f"ERROR: type {chr(65 + i % 26)}{chr(65 + (i // 26) % 26)} " + "x" * 280
+            )
+            for i in range(100)
+        ]
+        client = _mock_logs_client(get_results_rows=rows)
+        mock_session.return_value.client.return_value = client
 
-    def test_over_budget_evicts(self) -> None:
-        big_entry = {"@message": "x" * 30000}
-        entries = [big_entry, big_entry, big_entry]
-        result, truncated = _apply_token_budget(entries)
-        assert len(result) < len(entries)
-        assert truncated is True
+        collector = CloudWatchCollector()
+        result = collector.collect(_aws_config())
 
-    def test_estimate_tokens_basic(self) -> None:
-        entries = [{"@message": "a" * 400}]
-        tokens = _estimate_tokens(entries)
-        assert tokens > 0
+        total_chars = sum(
+            len(e.get("@message", "")) + len(e.get("@timestamp", ""))
+            for e in result.entries
+        )
+        estimated_tokens = total_chars // 4
+        assert estimated_tokens <= 6500  # allow some slack for our estimate
+        assert result.truncated is True
+        assert len(result.entries) < 100
 
 
 # ---------------------------------------------------------------------------
-# CloudWatchCollector.validate_config
+# Empty results
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyResults:
+    """NoDataError when query returns zero results."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_zero_results_raises_no_data_error(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = _mock_logs_client(get_results_rows=[])
+        mock_session.return_value.client.return_value = client
+
+        collector = CloudWatchCollector()
+
+        with pytest.raises(NoDataError) as exc_info:
+            collector.collect(_aws_config(time_window=15))
+
+        assert "No error-level logs" in exc_info.value.message
+        assert "15" in exc_info.value.message or "minutes" in exc_info.value.message
+        assert "log_groups" in exc_info.value.hint.lower() or "config" in exc_info.value.hint
+
+
+# ---------------------------------------------------------------------------
+# Auth failure
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFailure:
+    """NoCredentialsError → AWSAuthError with correct hint."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_no_credentials_raises_auth_error(
+        self, mock_session: MagicMock
+    ) -> None:
+        mock_session.return_value.client.side_effect = (
+            botocore.exceptions.NoCredentialsError()
+        )
+
+        collector = CloudWatchCollector()
+
+        with pytest.raises(AWSAuthError) as exc_info:
+            collector.validate_config(_aws_config())
+
+        assert "credentials not found" in exc_info.value.message.lower()
+        assert "aws configure" in exc_info.value.hint.lower() or "AWS_PROFILE" in exc_info.value.hint
+
+
+# ---------------------------------------------------------------------------
+# Permission failure
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionFailure:
+    """ClientError AccessDenied → AWSPermissionError."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_access_denied_raises_permission_error(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.side_effect = (
+            botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "Access Denied"}},
+                "DescribeLogGroups",
+            )
+        )
+        mock_session.return_value.client.return_value = client
+
+        collector = CloudWatchCollector()
+
+        with pytest.raises(AWSPermissionError) as exc_info:
+            collector.validate_config(_aws_config())
+
+        assert "permission" in exc_info.value.message.lower()
+        assert "logs:DescribeLogGroups" in exc_info.value.hint
+        assert "logs:StartQuery" in exc_info.value.hint
+
+
+# ---------------------------------------------------------------------------
+# Expired creds
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredCreds:
+    """ClientError ExpiredToken → AWSAuthError."""
+
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_expired_token_raises_auth_error(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.side_effect = (
+            botocore.exceptions.ClientError(
+                {"Error": {"Code": "ExpiredToken", "Message": "Token expired"}},
+                "DescribeLogGroups",
+            )
+        )
+        mock_session.return_value.client.return_value = client
+
+        collector = CloudWatchCollector()
+
+        with pytest.raises(AWSAuthError) as exc_info:
+            collector.validate_config(_aws_config())
+
+        assert "expired" in exc_info.value.message.lower()
+        assert "sso login" in exc_info.value.hint.lower() or "session token" in exc_info.value.hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# Query timeout
+# ---------------------------------------------------------------------------
+
+
+class TestQueryTimeout:
+    """get_query_results never completes → CollectorError."""
+
+    @patch("autopsy.collectors.cloudwatch.time.sleep")  # speed up test
+    @patch("autopsy.collectors.cloudwatch.boto3.Session")
+    def test_poll_timeout_raises_collector_error(
+        self, mock_session: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        def always_running():
+            while True:
+                yield {"status": "Running", "results": []}
+
+        client = _mock_logs_client(get_results_side_effect=always_running())
+        mock_session.return_value.client.return_value = client
+
+        collector = CloudWatchCollector()
+
+        with pytest.raises(CollectorError) as exc_info:
+            collector.collect(_aws_config())
+
+        assert "timeout" in exc_info.value.message.lower() or "30" in exc_info.value.message
+
+
+# ---------------------------------------------------------------------------
+# _result_row_to_entry
+# ---------------------------------------------------------------------------
+
+
+class TestResultRowToEntry:
+    """Conversion from Logs Insights row to entry dict."""
+
+    def test_maps_timestamp_message_logstream(self) -> None:
+        row = _insights_row(timestamp="2026-03-06T10:00:00Z", message="ERROR: fail")
+        entry = _result_row_to_entry(row)
+        assert entry["@timestamp"] == "2026-03-06T10:00:00Z"
+        assert entry["@message"] == "ERROR: fail"
+        assert entry["@logStream"] == "stream1"
+
+    def test_missing_message_defaults_empty(self) -> None:
+        row = [{"field": "@timestamp", "value": "2026-03-06T10:00:00Z"}]
+        entry = _result_row_to_entry(row)
+        assert entry["@message"] == ""
+        assert entry["@timestamp"] == "2026-03-06T10:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# validate_config
 # ---------------------------------------------------------------------------
 
 
 class TestValidateConfig:
-    """Auth and permission validation via mocked boto3."""
+    """validate_config with mocked boto3."""
 
     @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_valid_credentials(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.describe_log_groups.return_value = {"logGroups": []}
-        mock_session_cls.return_value.client.return_value = mock_client
+    def test_success_returns_true(
+        self, mock_session: MagicMock
+    ) -> None:
+        client = _mock_logs_client()
+        mock_session.return_value.client.return_value = client
 
         collector = CloudWatchCollector()
         assert collector.validate_config(_aws_config()) is True
 
     @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_expired_token_raises(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        error_response = {"Error": {"Code": "ExpiredTokenException", "Message": "expired"}}
-        mock_client.describe_log_groups.side_effect = ClientError(
-            error_response, "DescribeLogGroups"
-        )
-        mock_session_cls.return_value.client.return_value = mock_client
+    def test_log_group_not_found_raises(
+        self, mock_session: MagicMock
+    ) -> None:
+        # Paginator returns no matching log group name
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = iter([
+            {"logGroups": [{"logGroupName": "/other/group"}]},
+        ])
+        client.get_paginator.return_value = paginator
+        mock_session.return_value.client.return_value = client
 
         collector = CloudWatchCollector()
-        with pytest.raises(AWSAuthError):
-            collector.validate_config(_aws_config())
 
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_access_denied_raises(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        error_response = {"Error": {"Code": "AccessDeniedException", "Message": "denied"}}
-        mock_client.describe_log_groups.side_effect = ClientError(
-            error_response, "DescribeLogGroups"
-        )
-        mock_session_cls.return_value.client.return_value = mock_client
+        with pytest.raises(AWSPermissionError) as exc_info:
+            collector.validate_config(_aws_config(log_groups=["/aws/lambda/my-api"]))
 
-        collector = CloudWatchCollector()
-        with pytest.raises(AWSPermissionError):
-            collector.validate_config(_aws_config())
+        assert "not found" in exc_info.value.message.lower()
 
 
 # ---------------------------------------------------------------------------
-# CloudWatchCollector.collect
+# name property
 # ---------------------------------------------------------------------------
 
 
-class TestCollect:
-    """Full collect() with mocked boto3 calls."""
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_happy_path(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Complete",
-            "results": [
-                _make_log_row("2026-03-06T10:00:00Z", "ERROR: NullPointerException in handler"),
-                _make_log_row("2026-03-06T10:01:00Z", "ERROR: TimeoutException after 5000ms"),
-            ],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
+class TestCloudWatchCollectorName:
+    def test_name_is_cloudwatch(self) -> None:
         collector = CloudWatchCollector()
-        result = collector.collect(_aws_config())
-
-        assert result.source == "cloudwatch"
-        assert result.data_type == "logs"
-        assert len(result.entries) == 2
-        assert result.entry_count == 2
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_empty_results_raises_no_data(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Complete",
-            "results": [],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        collector = CloudWatchCollector()
-        with pytest.raises(NoDataError):
-            collector.collect(_aws_config())
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_dedup_applied(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Complete",
-            "results": [
-                _make_log_row("t1", "Timeout after 100ms"),
-                _make_log_row("t2", "Timeout after 200ms"),
-                _make_log_row("t3", "Timeout after 300ms"),
-                _make_log_row("t4", "NullPointer in handler"),
-            ],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        collector = CloudWatchCollector()
-        result = collector.collect(_aws_config())
-
-        assert result.entry_count == 4
-        assert len(result.entries) == 2
-        assert result.truncated is True
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_auth_error_on_start_query(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        error_response = {"Error": {"Code": "ExpiredTokenException", "Message": "expired"}}
-        mock_client.start_query.side_effect = ClientError(error_response, "StartQuery")
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        collector = CloudWatchCollector()
-        with pytest.raises(AWSAuthError):
-            collector.collect(_aws_config())
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_profile_passed_to_session(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Complete",
-            "results": [
-                _make_log_row("t1", "ERROR: something broke"),
-            ],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        config = _aws_config()
-        config["profile"] = "my-profile"
-        collector = CloudWatchCollector()
-        collector.collect(config)
-
-        mock_session_cls.assert_called_with(profile_name="my-profile")
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_multiple_log_groups(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Complete",
-            "results": [
-                _make_log_row("t1", "ERROR: from group A"),
-            ],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        config = _aws_config()
-        config["log_groups"] = ["/aws/lambda/api-a", "/aws/lambda/api-b"]
-        collector = CloudWatchCollector()
-        result = collector.collect(config)
-
-        assert mock_client.start_query.call_count == 2
-        assert result.entry_count == 2
-
-    @patch("autopsy.collectors.cloudwatch.boto3.Session")
-    def test_failed_query_returns_empty(self, mock_session_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client.start_query.return_value = {"queryId": "q-123"}
-        mock_client.get_query_results.return_value = {
-            "status": "Failed",
-            "results": [],
-        }
-        mock_session_cls.return_value.client.return_value = mock_client
-
-        collector = CloudWatchCollector()
-        with pytest.raises(NoDataError):
-            collector.collect(_aws_config())
+        assert collector.name == "cloudwatch"

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -1,3 +1,266 @@
-"""Tests for autopsy.diagnosis — orchestrator integration tests."""
+"""Tests for autopsy.diagnosis — orchestrator integration tests.
+
+Integration tests with fully mocked collectors and AI engine.
+"""
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autopsy.ai.models import (
+    CorrelatedDeploy,
+    DiagnosisResult,
+    RootCause,
+    SuggestedFix,
+    TimelineEvent,
+)
+from autopsy.config import AIConfig, AutopsyConfig, AWSConfig, GitHubConfig, OutputConfig
+from autopsy.diagnosis import DiagnosisOrchestrator
+from autopsy.renderers.json_out import JSONRenderer
+from autopsy.renderers.terminal import TerminalRenderer
+
+
+def _minimal_config() -> AutopsyConfig:
+    """Build minimal AutopsyConfig for tests."""
+    return AutopsyConfig(
+        aws=AWSConfig(
+            region="us-east-1",
+            log_groups=["/aws/lambda/test"],
+            time_window=30,
+        ),
+        github=GitHubConfig(
+            repo="owner/repo",
+            token_env="GITHUB_TOKEN",
+            deploy_count=5,
+            branch="main",
+        ),
+        ai=AIConfig(
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            api_key_env="ANTHROPIC_API_KEY",
+        ),
+        output=OutputConfig(),
+    )
+
+
+def _sample_result() -> DiagnosisResult:
+    """Sample DiagnosisResult for assertions."""
+    return DiagnosisResult(
+        root_cause=RootCause(
+            summary="Test root cause",
+            category="code_change",
+            confidence=0.9,
+            evidence=["line 1", "line 2"],
+        ),
+        correlated_deploy=CorrelatedDeploy(
+            commit_sha="abc123",
+            author="dev",
+            pr_title="fix: thing",
+            changed_files=["src/foo.py"],
+        ),
+        suggested_fix=SuggestedFix(
+            immediate="Revert abc123",
+            long_term="Add tests",
+        ),
+        timeline=[
+            TimelineEvent(time="2026-03-06T10:00:00Z", event="Deploy"),
+            TimelineEvent(time="2026-03-06T10:05:00Z", event="Error"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# DiagnosisOrchestrator.run — mocked collectors + AI
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorRun:
+    """Orchestrator run() with mocked CloudWatch, GitHub, and AI."""
+
+    @patch("autopsy.diagnosis.AIEngine")
+    @patch("autopsy.diagnosis.GitHubCollector")
+    @patch("autopsy.diagnosis.CloudWatchCollector")
+    def test_run_returns_ai_result(
+        self,
+        mock_cw_cls: MagicMock,
+        mock_gh_cls: MagicMock,
+        mock_engine_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp-test")
+
+        mock_cw = MagicMock()
+        mock_cw.validate_config.return_value = True
+        mock_cw.collect.return_value = MagicMock(source="cloudwatch", data_type="logs")
+        mock_cw_cls.return_value = mock_cw
+
+        mock_gh = MagicMock()
+        mock_gh.validate_config.return_value = True
+        mock_gh.collect.return_value = MagicMock(source="github", data_type="deploys")
+        mock_gh_cls.return_value = mock_gh
+
+        expected = _sample_result()
+        mock_engine = MagicMock()
+        mock_engine.diagnose.return_value = expected
+        mock_engine_cls.return_value = mock_engine
+
+        config = _minimal_config()
+        orch = DiagnosisOrchestrator(config)
+        result = orch.run()
+
+        assert result.root_cause.summary == "Test root cause"
+        assert result.root_cause.confidence == 0.9
+        mock_cw.validate_config.assert_called_once()
+        mock_cw.collect.assert_called_once()
+        mock_gh.validate_config.assert_called_once()
+        mock_gh.collect.assert_called_once()
+        mock_engine.diagnose.assert_called_once()
+        call_args = mock_engine.diagnose.call_args[0][0]
+        assert len(call_args) == 2
+
+    @patch("autopsy.diagnosis.AIEngine")
+    @patch("autopsy.diagnosis.GitHubCollector")
+    @patch("autopsy.diagnosis.CloudWatchCollector")
+    def test_run_passes_overrides_to_collect(
+        self,
+        mock_cw_cls: MagicMock,
+        mock_gh_cls: MagicMock,
+        mock_engine_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp-test")
+
+        mock_cw = MagicMock()
+        mock_cw.validate_config.return_value = True
+        mock_cw.collect.return_value = MagicMock()
+        mock_cw_cls.return_value = mock_cw
+
+        mock_gh = MagicMock()
+        mock_gh.validate_config.return_value = True
+        mock_gh.collect.return_value = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        mock_engine_cls.return_value.diagnose.return_value = _sample_result()
+
+        config = _minimal_config()
+        orch = DiagnosisOrchestrator(config)
+        orch.run(time_window=15, log_groups=["/custom/group"], provider="openai")
+
+        cw_collect_call = mock_cw.collect.call_args[0][0]
+        assert cw_collect_call["time_window"] == 15
+        assert cw_collect_call["log_groups"] == ["/custom/group"]
+        mock_engine_cls.assert_called_once()
+        assert mock_engine_cls.call_args[1]["provider"] == "openai"
+
+    @patch("autopsy.diagnosis.AIEngine")
+    @patch("autopsy.diagnosis.GitHubCollector")
+    @patch("autopsy.diagnosis.CloudWatchCollector")
+    def test_run_raises_when_ai_key_missing(
+        self,
+        mock_cw_cls: MagicMock,
+        mock_gh_cls: MagicMock,
+        mock_engine_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp-test")
+
+        config = _minimal_config()
+        orch = DiagnosisOrchestrator(config)
+
+        from autopsy.utils.errors import AIAuthError
+
+        with pytest.raises(AIAuthError, match="not set"):
+            orch.run()
+
+
+# ---------------------------------------------------------------------------
+# Renderers (smoke tests with sample_diagnosis_result)
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalRenderer:
+    """Terminal renderer produces output without error."""
+
+    def test_render_does_not_raise(self, sample_diagnosis_result: DiagnosisResult) -> None:
+        r = TerminalRenderer()
+        r.render(sample_diagnosis_result)
+
+    def test_render_with_raw_response(self, sample_diagnosis_result: DiagnosisResult) -> None:
+        sample_diagnosis_result.raw_response = "Raw fallback text"
+        r = TerminalRenderer()
+        r.render(sample_diagnosis_result)
+
+
+class TestJSONRenderer:
+    """JSON renderer outputs valid JSON."""
+
+    def test_render_outputs_valid_json(
+        self, sample_diagnosis_result: DiagnosisResult, capsys: pytest.CaptureFixture
+    ) -> None:
+        r = JSONRenderer()
+        r.render(sample_diagnosis_result)
+        out, _ = capsys.readouterr()
+        assert '"root_cause"' in out
+        assert '"summary"' in out
+        assert '"correlated_deploy"' in out
+        assert "\n  " in out
+
+
+# ---------------------------------------------------------------------------
+# CLI diagnose — integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIDiagnose:
+    """CLI diagnose command with mocked pipeline."""
+
+    @patch("autopsy.diagnosis.DiagnosisOrchestrator")
+    @patch("autopsy.config.load_config")
+    def test_diagnose_calls_orchestrator_and_renderer(
+        self,
+        mock_load_config: MagicMock,
+        mock_orch_cls: MagicMock,
+    ) -> None:
+        from click.testing import CliRunner
+
+        from autopsy.cli import cli
+
+        mock_load_config.return_value = _minimal_config()
+        mock_orch = MagicMock()
+        mock_orch.run.return_value = _sample_result()
+        mock_orch_cls.return_value = mock_orch
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diagnose"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        mock_orch.run.assert_called_once()
+        assert "Root Cause" in result.output or "root_cause" in result.output
+
+    @patch("autopsy.diagnosis.DiagnosisOrchestrator")
+    @patch("autopsy.config.load_config")
+    def test_diagnose_json_flag_outputs_json(
+        self,
+        mock_load_config: MagicMock,
+        mock_orch_cls: MagicMock,
+    ) -> None:
+        from click.testing import CliRunner
+
+        from autopsy.cli import cli
+
+        mock_load_config.return_value = _minimal_config()
+        mock_orch = MagicMock()
+        mock_orch.run.return_value = _sample_result()
+        mock_orch_cls.return_value = mock_orch
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diagnose", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert '"root_cause"' in result.output
+        assert '"summary"' in result.output


### PR DESCRIPTION
… fix

- Replace CloudWatch collector stub with full implementation:
  - validate_config: boto3 session, describe_log_groups, AWS error wrapping
  - collect: start_query + poll get_query_results, 4-stage reduction pipeline
  - Stage 1: query filter (error|exception|fatal|panic|timeout|5xx)
  - Stage 2: dedup by message template + occurrences
  - Stage 3: 500-char truncation, stack traces to 5 frames
  - Stage 4: 6000-token budget, FIFO eviction, truncated flag
- Add tests/test_cloudwatch.py: happy path, dedup, truncation, token budget, empty results, auth/permission/expired/query-timeout, _extract_template
- Fix github.py: catch only GithubException in _find_pr_for_commit (CTO checklist)
- Ruff fixes in cloudwatch: line length, unused loop var, combined if branches

